### PR TITLE
fix 未勾选在新标签页中打开的情况下，单击书签无法打开网址

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -670,19 +670,16 @@ function init() {
 	var openBookmarksLimit = 10;
 	var actions = {
 		openBookmark: function(url){
-			chrome.tabs.query({ active: true }, tabs => {
-				const tab = tabs[0];
-				try {
-                    decodedURL = decodeURIComponent(url);
-                } catch (e) {
-                    return;
-                }
-				chrome.tabs.update({
-					url: decodedURL
-				});
-				
-				if (!bookmarkClickStayOpen) setTimeout(window.close, 200);
+			try {
+				decodedURL = decodeURIComponent(url);
+			} catch (e) {
+				return;
+			}
+			chrome.tabs.update({
+				url: decodedURL
 			});
+			
+			if (!bookmarkClickStayOpen) setTimeout(window.close, 200);
 		},
 
 		openBookmarkNewTab: function(url, selected, blankTabCheck){

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -677,9 +677,10 @@ function init() {
                 } catch (e) {
                     return;
                 }
-				chrome.tabs.update(tab.id, {
+				chrome.tabs.update({
 					url: decodedURL
 				});
+				
 				if (!bookmarkClickStayOpen) setTimeout(window.close, 200);
 			});
 		},


### PR DESCRIPTION
chrome.tabs.update 缺省tabId既可以在当前标签页中打开网址