### PR TITLE
Fix "blankTabCheck" sometimes doesn't work

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -692,7 +692,7 @@ function ready (window) {
 				});
 			};
 			if (blankTabCheck){
-				chrome.tabs.query({ active: true }, tabs => {
+				chrome.tabs.query({ currentWindow: true, active: true }, tabs => {
 					const tab = tabs[0]
 
 					if (/^chrome:\/\/newtab/i.test(tab.url)){


### PR DESCRIPTION
使用 chrome.tabs.query({ currentWindow: true, active: true }) 获取当前选项卡